### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image-success.yml
+++ b/.github/workflows/docker-image-success.yml
@@ -28,7 +28,7 @@ jobs:
       - name: BuildDockerImage
         run: docker build . --file Dockerfile --tag twwch/action-ci:${{ github.ref_name	 }}
       - name: Publish to Docker Repository
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: twwch/action-ci:${{ github.ref_name	 }}
           repository: twwch/action-ci


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore